### PR TITLE
UCX: add ucp rma based plugin

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '10'))
-        timeout(time: 25, unit: 'MINUTES')
+        timeout(time: 35, unit: 'MINUTES')
         disableConcurrentBuilds()
     }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '10'))
-        timeout(time: 35, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
         disableConcurrentBuilds()
     }
 

--- a/.ci/configure_sharp.sh
+++ b/.ci/configure_sharp.sh
@@ -344,7 +344,7 @@ verify_sharp() {
             -x SHARP_COLL_JOB_QUOTA_PAYLOAD_PER_OST=256 \
             taskset -c 1 \
                 numactl --membind=0 \
-                    $OMPI_HOME/tests/osu-micro-benchmarks-5.3.2/osu_allreduce \
+                    $HPCX_OSU_DIR/osu_allreduce \
                         -i 100 \
                         -x 100 \
                         -f \
@@ -388,7 +388,7 @@ verify_sharp() {
             -x SHARP_COLL_ENABLE_SAT=1 \
             taskset -c 1 \
                 numactl --membind=0 \
-                    $OMPI_HOME/tests/osu-micro-benchmarks-5.3.2/osu_allreduce \
+                    $HPCX_OSU_DIR/osu_allreduce \
                         -i 100 \
                         -x 100 \
                         -f \

--- a/.ci/run_nccl_tests.sh
+++ b/.ci/run_nccl_tests.sh
@@ -122,7 +122,7 @@ i=1
 #===================
 # NCCL_PLUGIN_P2P
 #===================
-for P2P_LAYER in ucx ib
+for P2P_LAYER in ucx_rma ucx ib
 do
     MPIRUN_OPTIONS_PLUGIN_P2P_LAYER="-x NCCL_PLUGIN_P2P=${P2P_LAYER}"
 

--- a/.ci/run_nccl_tests.sh
+++ b/.ci/run_nccl_tests.sh
@@ -58,20 +58,8 @@ ITER=100
 WARMUP_ITER=100
 MSG_SIZE_MIN="8"
 MSG_SIZE_MAX="4M"
-# MPI_APP="hostname"
-MPI_APP="\
-${AFFINITY} \
-${NCCL_TESTS_DIR}/build/all_reduce_perf \
-    -b ${MSG_SIZE_MIN} \
-    -e ${MSG_SIZE_MAX} \
-    -f 2 \
-    -g 1 \
-    -c 1 \
-    -z 1 \
-    -n $ITER \
-    -w $WARMUP_ITER \
-    -p 0 \
-"
+NCCL_TEST_EXE=("all_reduce_perf" "all_gather_perf" "broadcast_perf" "reduce_perf" "reduce_scatter_perf" "alltoall_perf")
+NCCL_TEST_PARAMS=" -b ${MSG_SIZE_MIN} -e ${MSG_SIZE_MAX} -f 2 -g 1 -c 1 -z 1 -n $ITER -w $WARMUP_ITER -p 0 "
 ENABLE_SAT=${ENABLE_SAT:-1}
 echo "INFO: ENABLE_SAT = ${ENABLE_SAT}"
 
@@ -119,121 +107,123 @@ trim_multiple_spaces() {
 ###############################################################################
 
 i=1
-#===================
-# NCCL_PLUGIN_P2P
-#===================
-for P2P_LAYER in ucx_rma ucx ib
+
+for TEST_EXE in ${NCCL_TEST_EXE[@]}
 do
-    MPIRUN_OPTIONS_PLUGIN_P2P_LAYER="-x NCCL_PLUGIN_P2P=${P2P_LAYER}"
-
     #===================
-    # NCCL_PROTO
+    # NCCL_PLUGIN_P2P
     #===================
-    for NCCL_PROTO in Simple LL DEFAULT
+    for P2P_LAYER in ucx ib
     do
-        if [ "${NCCL_PROTO}" = "DEFAULT" ]
-        then
-            MPIRUN_OPTIONS_NCCL_PROTO=""
-        else
-            MPIRUN_OPTIONS_NCCL_PROTO="-x NCCL_PROTO=${NCCL_PROTO}"
-        fi
+        MPIRUN_OPTIONS_PLUGIN_P2P_LAYER="-x NCCL_PLUGIN_P2P=${P2P_LAYER}"
 
         #===================
-        # NCCL_ALGO
+        # NCCL_PROTO
         #===================
-        for NCCL_ALGO in CollNet Tree Ring DEFAULT
+        for NCCL_PROTO in Simple LL DEFAULT
         do
-            if [ "${NCCL_ALGO}" = "DEFAULT" ]
+            if [ "${NCCL_PROTO}" = "DEFAULT" ]
             then
-                MPIRUN_OPTIONS_NCCL_ALGO=""
+                MPIRUN_OPTIONS_NCCL_PROTO=""
             else
-                MPIRUN_OPTIONS_NCCL_ALGO="-x NCCL_ALGO=${NCCL_ALGO}"
-            fi
-
-            if [ "${NCCL_ALGO}" = "CollNet" ]
-            then
-                MPIRUN_OPTIONS_NCCL_ALGO="-x NCCL_COLLNET_ENABLE=1 ${MPIRUN_OPTIONS_NCCL_ALGO}"
+                MPIRUN_OPTIONS_NCCL_PROTO="-x NCCL_PROTO=${NCCL_PROTO}"
             fi
 
             #===================
-            # SHARP_ENABLE
+            # NCCL_ALGO
             #===================
-            for SHARP_ENABLE in 0 1
+            for NCCL_ALGO in CollNet Tree Ring DEFAULT
             do
-                if [ "${SHARP_ENABLE}" = "0" ]
+                if [ "${NCCL_ALGO}" = "DEFAULT" ]
                 then
-                    MPIRUN_OPTIONS_SHARP=""
+                    MPIRUN_OPTIONS_NCCL_ALGO=""
                 else
-                    # TODO change to SHARP_COLL_SAT_THRESHOLD=1 (32 - W/A for SHARP issue)
-                    MPIRUN_OPTIONS_SHARP="\
-                        -x SHARP_COLL_LOG_LEVEL=3 \
-                        -x SHARP_COLL_ENABLE_SAT=${ENABLE_SAT} \
-                        -x SHARP_COLL_SAT_THRESHOLD=32 \
-                        "
+                    MPIRUN_OPTIONS_NCCL_ALGO="-x NCCL_ALGO=${NCCL_ALGO}"
+                fi
+
+                if [ "${NCCL_ALGO}" = "CollNet" ]
+                then
+                    MPIRUN_OPTIONS_NCCL_ALGO="-x NCCL_COLLNET_ENABLE=1 ${MPIRUN_OPTIONS_NCCL_ALGO}"
                 fi
 
                 #===================
-                # NCCL_NET_GDR_LEVEL
+                # SHARP_ENABLE
                 #===================
-                # for NCCL_NET_GDR_LEVEL in 0 1 2 3 4 5 DEFAULT
-                for NCCL_NET_GDR_LEVEL in DEFAULT
+                for SHARP_ENABLE in 0 1
                 do
-                    if [ "${NCCL_NET_GDR_LEVEL}" = "DEFAULT" ]
+                    if [ "${SHARP_ENABLE}" = "0" ]
                     then
-                        MPIRUN_OPTIONS_GDR_LEVEL=""
+                        MPIRUN_OPTIONS_SHARP=""
                     else
-                        MPIRUN_OPTIONS_GDR_LEVEL="-x NCCL_NET_GDR_LEVEL=${NCCL_NET_GDR_LEVEL}"
+                        MPIRUN_OPTIONS_SHARP="\
+                            -x SHARP_COLL_LOG_LEVEL=3 \
+                            -x SHARP_COLL_ENABLE_SAT=${ENABLE_SAT} \
+                            "
                     fi
 
                     #===================
-                    # NCCL_NET_GDR_READ
+                    # NCCL_NET_GDR_LEVEL
                     #===================
-                    # for NCCL_NET_GDR_READ in 0 1 DEFAULT
-                    for NCCL_NET_GDR_READ in DEFAULT
+                    # for NCCL_NET_GDR_LEVEL in 0 1 2 3 4 5 DEFAULT
+                    for NCCL_NET_GDR_LEVEL in DEFAULT
                     do
-                        if [ "${NCCL_NET_GDR_READ}" = "DEFAULT" ]
+                        if [ "${NCCL_NET_GDR_LEVEL}" = "DEFAULT" ]
                         then
-                            MPIRUN_OPTIONS_GDR_READ=""
+                            MPIRUN_OPTIONS_GDR_LEVEL=""
                         else
-                            MPIRUN_OPTIONS_GDR_READ="-x NCCL_NET_GDR_READ=${NCCL_NET_GDR_READ}"
+                            MPIRUN_OPTIONS_GDR_LEVEL="-x NCCL_NET_GDR_LEVEL=${NCCL_NET_GDR_LEVEL}"
                         fi
 
-                        echo_hash_line
-                        echo "# Test $i..."
-                        echo_hash_line
+                        #===================
+                        # NCCL_NET_GDR_READ
+                        #===================
+                        # for NCCL_NET_GDR_READ in 0 1 DEFAULT
+                        for NCCL_NET_GDR_READ in DEFAULT
+                        do
+                            if [ "${NCCL_NET_GDR_READ}" = "DEFAULT" ]
+                            then
+                                MPIRUN_OPTIONS_GDR_READ=""
+                            else
+                                MPIRUN_OPTIONS_GDR_READ="-x NCCL_NET_GDR_READ=${NCCL_NET_GDR_READ}"
+                            fi
 
-                        echo "INFO: NCCL_PROTO          = ${NCCL_PROTO}"
-                        echo "INFO: NCCL_ALGO           = ${NCCL_ALGO}"
-                        echo "INFO: SHARP_ENABLE        = ${SHARP_ENABLE}"
-                        echo "INFO: NCCL_NET_GDR_LEVEL  = ${NCCL_NET_GDR_LEVEL}"
-                        echo "INFO: NCCL_NET_GDR_READ   = ${NCCL_NET_GDR_READ}"
+                            echo_hash_line
+                            echo "# Test $i..."
+                            echo_hash_line
 
-                        CMD="mpirun \
-                            ${MPIRUN_OPTIONS_COMMON} \
-                            ${MPIRUN_OPTIONS_NCCL_PROTO} \
-                            ${MPIRUN_OPTIONS_NCCL_ALGO} \
-                            ${MPIRUN_OPTIONS_SHARP} \
-                            ${MPIRUN_OPTIONS_GDR_LEVEL} \
-                            ${MPIRUN_OPTIONS_GDR_READ} \
-                            ${MPIRUN_OPTIONS_PLUGIN_P2P_LAYER} \
-                            ${MPI_APP}"
-                        echo "# Test $i reproducer:"
-                        echo "export PATH=${PATH}"
-                        echo ""
-                        echo "export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
-                        echo ""
-                        echo "export OPAL_PREFIX=${OPAL_PREFIX}"
-                        echo ""
-                        trim_multiple_spaces "$CMD"
-                        if ! $CMD
-                        then
-                            echo "# Test $i... failed"
-                            GLOBAL_TEST_STATUS=1
-                        else
-                            echo "# Test $i... passed"
-                        fi
+                            echo "INFO: NCCL_PROTO          = ${NCCL_PROTO}"
+                            echo "INFO: NCCL_ALGO           = ${NCCL_ALGO}"
+                            echo "INFO: SHARP_ENABLE        = ${SHARP_ENABLE}"
+                            echo "INFO: NCCL_NET_GDR_LEVEL  = ${NCCL_NET_GDR_LEVEL}"
+                            echo "INFO: NCCL_NET_GDR_READ   = ${NCCL_NET_GDR_READ}"
 
-                        i=$((i + 1))
+                            CMD="mpirun \
+                                ${MPIRUN_OPTIONS_COMMON} \
+                                ${MPIRUN_OPTIONS_NCCL_PROTO} \
+                                ${MPIRUN_OPTIONS_NCCL_ALGO} \
+                                ${MPIRUN_OPTIONS_SHARP} \
+                                ${MPIRUN_OPTIONS_GDR_LEVEL} \
+                                ${MPIRUN_OPTIONS_GDR_READ} \
+                                ${MPIRUN_OPTIONS_PLUGIN_P2P_LAYER} \
+                                ${NCCL_TESTS_DIR}/build/${NCCL_TEST_EXE[$TEST_EXE]} ${NCCL_TEST_PARAMS}"
+                            echo "# Test $i reproducer:"
+                            echo "export PATH=${PATH}"
+                            echo ""
+                            echo "export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+                            echo ""
+                            echo "export OPAL_PREFIX=${OPAL_PREFIX}"
+                            echo ""
+                            trim_multiple_spaces "$CMD"
+                            if ! $CMD
+                            then
+                                echo "# Test $i... failed"
+                                GLOBAL_TEST_STATUS=1
+                            else
+                                echo "# Test $i... passed"
+                            fi
+
+                            i=$((i + 1))
+                        done
                     done
                 done
             done

--- a/include/p2p_plugin.h
+++ b/include/p2p_plugin.h
@@ -21,6 +21,7 @@
 typedef enum nccl_p2p_plugin {
   NCCL_P2P_IB,
   NCCL_P2P_UCX,
+  NCCL_P2P_UCX_RMA,
   NCCL_P2P_LAST
 } nccl_p2p_plugin_t;
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,9 @@ if HAVE_UCX_PLUGIN
 libnccl_net_la_CPPFLAGS  = -DHAVE_UCX_PLUGIN $(UCX_CPPFLAGS)
 libnccl_net_la_LIBADD   += $(UCX_LIBADD)
 libnccl_net_la_LDFLAGS  += $(UCX_LDFLAGS) 
-libnccl_net_la_SOURCES  += ucx_plugin.c
+libnccl_net_la_SOURCES  += \
+	ucx_plugin.c \
+	ucx_rma_plugin.c
 endif
 
 if HAVE_SHARP_PLUGIN

--- a/src/p2p_plugin.c
+++ b/src/p2p_plugin.c
@@ -19,6 +19,7 @@
 
 #ifdef HAVE_UCX_PLUGIN
 extern ncclNet_t ucxPlugin;
+extern ncclNet_t ucxRmaPlugin;
 #endif
 
 extern ncclNet_t ibPlugin;
@@ -73,6 +74,7 @@ ncclResult_t pluginInit(ncclDebugLogger_t logFunction)
     if (!strcasecmp(p2p_layer, "ib")) p2p_plugin = NCCL_P2P_IB;
 #ifdef HAVE_UCX_PLUGIN
     else if (!strcasecmp(p2p_layer, "ucx")) p2p_plugin = NCCL_P2P_UCX;
+    else if (!strcasecmp(p2p_layer, "ucx_rma")) p2p_plugin = NCCL_P2P_UCX_RMA;
 #endif
     else {
       WARN("Invalid value %s for NCCL_PLUGIN_P2P, using default.", p2p_layer);
@@ -86,9 +88,13 @@ ncclResult_t pluginInit(ncclDebugLogger_t logFunction)
     case NCCL_P2P_UCX:
       NCCL_PLUGIN_SYMBOL = ucxPlugin;
       break;
+    case NCCL_P2P_UCX_RMA:
+      NCCL_PLUGIN_SYMBOL = ucxRmaPlugin;
+      break;
 #endif
+  }
   INFO(NCCL_INIT|NCCL_NET, "P2P plugin %s", NCCL_PLUGIN_SYMBOL.name);
-}
+
 
   return NCCL_PLUGIN_SYMBOL.init(logFunction);
 }

--- a/src/ucx_rma_plugin.c
+++ b/src/ucx_rma_plugin.c
@@ -1,0 +1,1062 @@
+/*************************************************************************
+ *  * Copyright (c) 2016-2020, NVIDIA CORPORATION. All rights reserved.
+ *   *
+ *    * See LICENSE.txt for license information
+ *     ************************************************************************/
+
+#include <pthread.h>
+#include <stdint.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include "core.h"
+#include "ibvwrap.h"
+#include "nccl.h"
+#include "nccl_net.h"
+#include "p2p_plugin.h"
+#include "param.h"
+#include "socket.h"
+#include "ucp/api/ucp.h"
+
+
+#define UCXCHECK(cmd) do {                           \
+  int e = cmd;                                       \
+  if( UCS_OK != e ) {                                \
+    WARN("Failed: UCX error %s:%d '%d' %s\n",        \
+        __FILE__,__LINE__, e, ucs_status_string(e)); \
+    return ncclInternalError;                        \
+  }                                                  \
+} while(0)
+
+#define UCXCHECK_VOID(cmd) do {                      \
+  int e = cmd;                                       \
+  if( UCS_OK != e ) {                                \
+    WARN("Failed: UCX error %s:%d '%d' %s\n",        \
+        __FILE__,__LINE__, e, ucs_status_string(e)); \
+  }                                                  \
+} while(0)
+
+NCCL_PARAM(UCXRMADisable, "UCX_RMA_DISABLE", 0);
+
+extern ncclDebugLogger_t pluginLogFunction;
+static char nccl_ucx_rma_tls[32] = "";
+static char nccl_ucx_rma_zcopy_thresh[32] ="";
+static int ncclNIbDevs = -1;
+
+typedef struct ucx_rma_mhandle {
+  ucp_mem_h  ucp_memh;
+  ucp_rkey_h rkey;
+  void       *rkey_buf;
+  size_t     rkey_buf_size;
+  int        index;
+} ucx_rma_mhandle_t;
+
+struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
+struct userIbDev userIbDevs[MAX_IB_DEVS];
+
+ncclResult_t nccl_ucx_rma_devices(int* ndev) {
+  *ndev = ncclNIbDevs;
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_get_properties(int dev, ncclNetProperties_t* props)
+{
+  return nccl_p2p_ib_get_properties(ncclIbDevs, dev, props);
+}
+
+pthread_mutex_t nccl_ucx_rma_lock = PTHREAD_MUTEX_INITIALIZER;
+
+typedef struct ucx_rma_listen_handle {
+  union socketAddress connectAddr;
+} ucx_rma_listen_handle_t;
+
+typedef struct nccl_ucx_rma_listen_comm {
+  int dev;
+  int fd;
+} nccl_ucx_rma_listen_comm_t;
+
+struct ep_list {
+  int            fd;
+  struct ep_list *next;
+};
+
+struct nccl_ucx_worker {
+  ucp_context_h  ctx;
+  ucp_worker_h   worker;
+  int            count;
+  struct ep_list *eps;
+};
+static struct nccl_ucx_worker workers[MAX_IB_DEVS];
+
+typedef struct ucx_gpu_flush {
+  int      enabled;
+  int      hostMem;
+  ucp_ep_h flush_ep;
+} ucx_gpu_flush_t;
+
+enum {
+  UCX_RMA_REQ_TYPE_SEND,
+  UCX_RMA_REQ_TYPE_RECV
+};
+
+typedef struct nccl_ucx_rma_request {
+  char             ucx_req[256];
+  int              used;
+  int              type;
+  int              done;
+  int              size;
+  int              free;
+  uint64_t         am_msg;
+  int              seq;
+  ucs_status_ptr_t st;
+  ucp_worker_h     worker;
+} nccl_ucx_rma_request_t;
+
+typedef struct ucx_rma_send_fifo {
+  uint64_t addr;
+  uint64_t addr_request;
+  int      size;
+  uint32_t seq;
+  uint32_t ready;
+  int      rkey_idx;
+  int      req_id;
+  char     rkey_buf[40];
+} ucx_rma_send_fifo_t;
+
+typedef struct nccl_ucx_rma_ctx {
+  int                    id;
+  int                    fd;
+  int                    ready;
+  ucs_status_ptr_t       check_req;
+  ucp_context_h          ctx;
+  ucp_worker_h           worker;
+  ucx_gpu_flush_t        gpuFlush;
+  uint64_t               num_mh;
+  ucx_rma_mhandle_t      *mh[16];
+  nccl_ucx_rma_request_t reqs[MAX_REQUESTS];
+} nccl_ucx_rma_ctx_t;
+
+typedef struct nccl_ucx_rma_send_comm {
+  nccl_ucx_rma_ctx_t  super;
+  ucp_ep_h            ep;
+  ucx_rma_send_fifo_t fifo[MAX_REQUESTS];
+  uint32_t            fifo_head;
+  ucp_mem_h           fifo_memh;
+  ucp_rkey_h          rem_key[16];
+  int                 rem_am_id;
+} nccl_ucx_rma_send_comm_t;
+
+typedef struct ucx_rma_rem_fifo {
+  ucx_rma_send_fifo_t elems[MAX_REQUESTS];
+  uint64_t            addr;
+  ucp_rkey_h          rkey;
+  uint32_t            tail;
+} ucx_rma_rem_fifo_t;
+
+typedef struct nccl_ucx_rma_recv_comm {
+  nccl_ucx_rma_ctx_t super;
+  ucp_ep_h           ep;
+  ucx_rma_rem_fifo_t rem_fifo;
+  int                rem_am_id;
+  void               *rkey_bufs;
+} nccl_ucx_rma_recv_comm_t;
+
+
+static union socketAddress nccl_ucx_if_addr;
+static char if_name[MAX_IF_NAME_SIZE];
+
+static ncclResult_t get_socket_addr(union socketAddress *addr)
+{
+  memcpy(addr, &nccl_ucx_if_addr, sizeof(*addr));
+  return ncclSuccess;
+}
+
+typedef struct nccl_ucx_am_request {
+  nccl_ucx_rma_request_t *req;
+} nccl_ucx_am_request_t;
+
+static ncclResult_t nccl_ucx_rma_init_ucp(int dev, ucp_context_h *ctx)
+{
+  ucp_params_t ucp_params;
+  ucp_config_t *config;
+  char         ucx_dev_name[PATH_MAX];
+
+  snprintf(ucx_dev_name, PATH_MAX, "%s:%d", ncclIbDevs[dev].devName,
+           ncclIbDevs[dev].port);
+  UCXCHECK(ucp_config_read("NCCL", NULL, &config));
+
+  UCXCHECK(ucp_config_modify(config, "NET_DEVICES", ucx_dev_name));
+  UCXCHECK(ucp_config_modify(config, "TLS", nccl_ucx_rma_tls));
+  UCXCHECK(ucp_config_modify(config, "ZCOPY_THRESH", nccl_ucx_rma_zcopy_thresh));
+
+  memset(&ucp_params, 0, sizeof(ucp_params));
+  ucp_params.field_mask   = UCP_PARAM_FIELD_FEATURES |
+                            UCP_PARAM_FIELD_REQUEST_SIZE;
+  ucp_params.features     = UCP_FEATURE_RMA |
+                            UCP_FEATURE_AM;
+  ucp_params.request_size = sizeof(nccl_ucx_am_request_t);
+
+  UCXCHECK(ucp_init(&ucp_params, config, ctx));
+  ucp_config_release(config);
+
+  return ncclSuccess;
+}
+
+static ncclResult_t nccl_ucx_rma_init_worker(ucp_context_h ctx,
+                                             ucp_worker_h *worker)
+{
+  ucp_worker_params_t worker_params;
+  ucp_worker_attr_t   worker_attr;
+
+  memset(&worker_params, 0, sizeof(worker_params));
+  worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+  worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
+
+  UCXCHECK(ucp_worker_create(ctx, &worker_params, worker));
+
+  worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_THREAD_MODE;
+  ucp_worker_query(*worker, &worker_attr);
+  if (worker_attr.thread_mode != UCS_THREAD_MODE_MULTI) {
+    INFO(NCCL_NET, "Thread mode multi is not supported");
+  }
+
+  return ncclSuccess;
+}
+
+#define UCX_RMA_USE_SHARED_WORKER
+static ncclResult_t nccl_ucx_rma_init_comm_context(int dev,
+                                                   nccl_ucx_rma_ctx_t *comm_ctx)
+{
+  pthread_mutex_lock(&nccl_ucx_rma_lock);
+#ifdef UCX_RMA_USE_SHARED_WORKER
+  if (workers[dev].count == 0) {
+    nccl_ucx_rma_init_ucp(dev, &workers[dev].ctx);
+    nccl_ucx_rma_init_worker(workers[dev].ctx, &workers[dev].worker);
+    workers->count = 0;
+    workers->eps   = NULL;
+  }
+
+  comm_ctx->ctx    = workers[dev].ctx;
+  comm_ctx->worker = workers[dev].worker;
+  comm_ctx->id     = workers[dev].count;
+  workers[dev].count++;
+#else
+  nccl_ucx_rma_init_ucp(dev, &comm_ctx->ctx);
+  nccl_ucx_rma_init_worker(comm_ctx->ctx, &comm_ctx->worker);
+#endif
+  pthread_mutex_unlock(&nccl_ucx_rma_lock);
+  return ncclSuccess;
+}
+
+static ncclResult_t nccl_ucx_rma_send_worker_address(ucp_worker_h worker, int fd)
+{
+  ucp_worker_attr_t attr;
+
+  attr.field_mask    = UCP_WORKER_ATTR_FIELD_ADDRESS |
+                       UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
+  attr.address_flags = UCP_WORKER_ADDRESS_FLAG_NET_ONLY;
+
+  UCXCHECK(ucp_worker_query(worker, &attr));
+  NCCLCHECK(socketSend(fd, &attr.address_length, sizeof(attr.address_length)));
+  NCCLCHECK(socketSend(fd, attr.address, attr.address_length));
+
+  free(attr.address);
+  return ncclSuccess;
+}
+
+static ncclResult_t nccl_ucx_free_worker(ucp_worker_h worker)
+{
+  int i;
+  int dummy;
+  struct ep_list *ep, *cur;
+
+  pthread_mutex_lock(&nccl_ucx_rma_lock);
+  for(i = 0; i < ncclNIbDevs; i++) {
+    if (worker == workers[i].worker) {
+      workers[i].count--;
+      if (workers[i].count == 0) {
+        ep = workers[i].eps;
+        while(ep) {
+          cur = ep;
+          NCCLCHECK(socketReceive(ep->fd, &dummy, sizeof(int)));
+          ep = ep->next;
+          close(cur->fd);
+          free(cur);
+        }
+        ucp_worker_destroy(workers[i].worker);
+        ucp_cleanup(workers[i].ctx);
+        INFO(NCCL_NET, "worker destroy");
+        workers[i].eps    = NULL;
+        workers[i].worker = NULL;
+        workers[i].ctx    = NULL;
+      }
+      break;
+    }
+  }
+  pthread_mutex_unlock(&nccl_ucx_rma_lock);
+
+  return ncclSuccess;
+}
+
+static ncclResult_t nccl_ucx_add_ep(ucp_worker_h worker, int fd)
+{
+  ncclResult_t status = ncclSuccess;
+  int i;
+
+  for(i = 0; i < ncclNIbDevs; i++) {
+    if (worker == workers[i].worker) {
+      struct ep_list *new_ep = (struct ep_list*)malloc(sizeof(struct ep_list));
+
+      if (new_ep == NULL) {
+        status = ncclSystemError;
+        break;
+      }
+
+      new_ep->fd   = fd;
+      new_ep->next = workers[i].eps;
+      workers[i].eps = new_ep;
+      break;
+    }
+  }
+
+  return status;
+}
+
+ncclResult_t nccl_ucx_rma_init(ncclDebugLogger_t logFunction)
+{
+  char *config_env;
+  if (ncclParamUCXRMADisable()) return ncclInternalError;
+  NCCLCHECK(nccl_p2p_ib_init(&ncclNIbDevs, ncclIbDevs, if_name, &nccl_ucx_if_addr,
+                          NULL, logFunction));
+
+  if (strlen(nccl_ucx_rma_tls) == 0) {
+    config_env = getenv("NCCL_UCX_TLS");
+    if (config_env != NULL) {
+      snprintf(nccl_ucx_rma_tls, 32, "%s", config_env);
+    } else {
+      snprintf(nccl_ucx_rma_tls, 32, "%s", "ib");
+    }
+    INFO(NCCL_NET, "NET/UCX_RMA: using transports: %s", nccl_ucx_rma_tls);
+  }
+
+  if (strlen(nccl_ucx_rma_zcopy_thresh) == 0) {
+    config_env = getenv("NCCL_UCX_ZCOPY_THRESH");
+    if (config_env != NULL) {
+      snprintf(nccl_ucx_rma_zcopy_thresh, 32, "%s", config_env);
+    } else {
+      snprintf(nccl_ucx_rma_zcopy_thresh, 32, "%s", "1");
+    }
+    INFO(NCCL_NET, "NET/UCX_RMA: zero copy threshold: %s", nccl_ucx_rma_zcopy_thresh);
+  }
+
+
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_listen(int dev, void *handle, void **listen_comm)
+{
+  ucx_rma_listen_handle_t *my_handle = (ucx_rma_listen_handle_t*)handle;
+  nccl_ucx_rma_listen_comm_t   *comm;
+
+  NCCL_STATIC_ASSERT(sizeof(ucx_rma_listen_handle_t) < NCCL_NET_HANDLE_MAXSIZE,
+                     "UCX-RMA listen handle size too large");
+
+  NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(nccl_ucx_rma_listen_comm_t)));
+  NCCLCHECK(get_socket_addr(&(my_handle->connectAddr)));
+  NCCLCHECK(createListenSocket(&comm->fd, &my_handle->connectAddr));
+
+  comm->dev = dev; 
+  *listen_comm = comm;
+ 
+  return ncclSuccess;
+}
+
+static ucs_status_t nccl_ucx_rma_am_rkey_cb(void *arg, void *data, size_t length,
+                                            ucp_ep_h reply_ep, unsigned flags)
+{
+  nccl_ucx_rma_send_comm_t *comm = (nccl_ucx_rma_send_comm_t*)arg;
+  char   *rkey_bufs = (char*)data;
+  size_t rkey_buf_size, rkey_buf_num;
+  int    i;
+
+  memcpy(&rkey_buf_num, rkey_bufs, sizeof(size_t));
+  memcpy(&rkey_buf_size, rkey_bufs + sizeof(size_t), sizeof(size_t));
+  rkey_bufs = rkey_bufs + 2 * sizeof(size_t);
+  for (i = 0; i < rkey_buf_num; i++) {
+    UCXCHECK(ucp_ep_rkey_unpack(comm->ep, rkey_bufs, &comm->rem_key[i]));
+    rkey_bufs += rkey_buf_size;
+  }
+
+  return UCS_OK;
+}
+
+ncclResult_t nccl_ucx_rma_connect(int dev, void *handle, void **send_comm)
+{
+  ucx_rma_listen_handle_t  *recv_handle = (ucx_rma_listen_handle_t*)handle;
+  nccl_ucx_rma_send_comm_t *comm;
+  ucp_mem_map_params_t     mmap_params;
+  size_t                   rkey_buf_size;
+  void                     *rkey_buf;
+  uint64_t                 fifo_adr;
+
+  NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(*comm)));
+  NCCLCHECK(connectAddress(&comm->super.fd, &recv_handle->connectAddr));
+  NCCLCHECK(nccl_ucx_rma_init_comm_context(dev, &comm->super));
+  NCCLCHECK(nccl_ucx_rma_send_worker_address(comm->super.worker, comm->super.fd));
+  NCCLCHECK(nccl_ucx_add_ep(comm->super.worker, comm->super.fd));
+  UCXCHECK(ucp_worker_set_am_handler(comm->super.worker, comm->super.id,
+                                     nccl_ucx_rma_am_rkey_cb, comm ,0));
+
+  fifo_adr = (uint64_t)comm->fifo;
+  mmap_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                           UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+  mmap_params.address    = (void*)fifo_adr;
+  mmap_params.length     = sizeof(ucx_rma_send_fifo_t) *
+                           MAX_REQUESTS;
+  ucp_mem_map(comm->super.ctx, &mmap_params, &comm->fifo_memh);
+  ucp_rkey_pack(comm->super.ctx, comm->fifo_memh, &rkey_buf, &rkey_buf_size);
+  NCCLCHECK(socketSend(comm->super.fd, &rkey_buf_size, sizeof(size_t)));
+  NCCLCHECK(socketSend(comm->super.fd, rkey_buf, rkey_buf_size));
+  NCCLCHECK(socketSend(comm->super.fd, &fifo_adr, sizeof(uint64_t)));
+  NCCLCHECK(socketSend(comm->super.fd, &comm->super.id, sizeof(comm->super.id)));
+  ucp_rkey_buffer_release(rkey_buf);
+  *send_comm = comm;
+
+  return ncclSuccess;
+}
+
+static ucs_status_t nccl_ucx_rma_am_cb(void *arg, void *data, size_t length,
+                                       ucp_ep_h reply_ep, unsigned flags)
+{
+  nccl_ucx_rma_request_t *reqs = (nccl_ucx_rma_request_t*)arg;
+  uint64_t *header = data;
+  int      size    = *header & 0xFFFFFFFFFFFFFFFF;
+  int      id      = *header >>32 ;
+
+  reqs[id].size = size;
+  reqs[id].done = 2;
+
+  return UCS_OK;
+}
+
+static ncclResult_t nccl_ucx_rma_init_ep(int fd, ucp_worker_h worker, ucp_ep_h *ep, int blocking)
+{
+  int bytes = 0;
+  ucp_ep_params_t ep_params;
+  size_t          peer_addr_len;
+  void            *peer_addr;
+
+  if (blocking) {
+    NCCLCHECK(socketReceive(fd, &peer_addr_len, sizeof(size_t)));
+  } else {
+    NCCLCHECK(socketProgress(NCCL_SOCKET_RECV, fd, &peer_addr_len,
+                            sizeof(size_t), &bytes));
+    if (bytes == 0) {
+      ep = NULL;
+      return ncclSuccess;
+    }
+    NCCLCHECK(socketWait(NCCL_SOCKET_RECV, fd, &peer_addr_len,
+                         sizeof(size_t), &bytes));
+  }
+  peer_addr = alloca(peer_addr_len);
+  NCCLCHECK(socketReceive(fd, peer_addr, peer_addr_len));
+
+  ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+  ep_params.address    = peer_addr;
+  UCXCHECK(ucp_ep_create(worker, &ep_params, ep));
+
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_accept(void *listen_comm, void **recv_comm)
+{
+  nccl_ucx_rma_listen_comm_t *l_comm = (nccl_ucx_rma_listen_comm_t *)listen_comm;
+  socklen_t                  socklen = sizeof(struct sockaddr_in);
+  nccl_ucx_rma_recv_comm_t   *comm;
+  struct sockaddr_in         sockaddr;
+  void                       *rkey_buf;
+  size_t                     rkey_buf_size;
+ 
+  NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(nccl_ucx_rma_recv_comm_t)));
+  SYSCHECKVAL(accept(l_comm->fd, (struct sockaddr*)&sockaddr, &socklen),
+              "accept", comm->super.fd);
+  NCCLCHECK(nccl_ucx_rma_init_comm_context(l_comm->dev, &comm->super));
+  UCXCHECK(ucp_worker_set_am_handler(comm->super.worker, comm->super.id,
+                                     nccl_ucx_rma_am_cb, comm->super.reqs,0));
+
+  NCCLCHECK(nccl_ucx_rma_init_ep(comm->super.fd, comm->super.worker, &comm->ep, 1));
+  NCCLCHECK(nccl_ucx_add_ep(comm->super.worker, comm->super.fd));
+  NCCLCHECK(socketReceive(comm->super.fd, &rkey_buf_size, sizeof(size_t)));
+
+  rkey_buf = malloc(rkey_buf_size);
+  if (rkey_buf == NULL) {
+    return ncclSystemError;
+  }
+  NCCLCHECK(socketReceive(comm->super.fd, rkey_buf, rkey_buf_size));
+  NCCLCHECK(socketReceive(comm->super.fd, &comm->rem_fifo.addr, sizeof(uint64_t)));
+  NCCLCHECK(socketReceive(comm->super.fd, &comm->rem_am_id, sizeof(int)));
+  UCXCHECK(ucp_ep_rkey_unpack(comm->ep, rkey_buf, &comm->rem_fifo.rkey));
+  free(rkey_buf);
+
+  if (nccl_p2p_gdr_support(l_comm->dev) == ncclSuccess) {
+    comm->super.gpuFlush.enabled = 1;
+  }
+
+  if (comm->super.gpuFlush.enabled) {
+    ucp_worker_attr_t attr;
+    ucp_ep_params_t   ep_params;
+
+    attr.field_mask    = UCP_WORKER_ATTR_FIELD_ADDRESS |
+                         UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
+    attr.address_flags = UCP_WORKER_ADDRESS_FLAG_NET_ONLY;
+
+    UCXCHECK(ucp_worker_query(comm->super.worker, &attr));
+    ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+    ep_params.address    = attr.address;
+    UCXCHECK(ucp_ep_create(comm->super.worker, &ep_params,
+                           &comm->super.gpuFlush.flush_ep));
+
+    free(attr.address);
+  }
+  comm->super.num_mh = 0;
+  *recv_comm = comm;
+
+  return ncclSuccess;
+}
+
+#define REG_ALIGN (4096)
+ncclResult_t nccl_ucx_rma_regmr(void* comm, void* data, int size, int type,
+                                void** mhandle)
+{
+  nccl_ucx_rma_ctx_t   *ctx = (nccl_ucx_rma_ctx_t*)comm;
+  uint64_t             addr = (uint64_t)data;
+  ucp_mem_map_params_t mmap_params;
+  ucx_rma_mhandle_t    *mh;
+  uint64_t             reg_addr, reg_size;
+  
+  reg_addr = addr & (~(REG_ALIGN - 1));
+  reg_size = addr + size - reg_addr;
+  reg_size = ROUNDUP(reg_size, REG_ALIGN);
+
+  mmap_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                           UCP_MEM_MAP_PARAM_FIELD_LENGTH; 
+  mmap_params.address    = (void*)reg_addr;
+  mmap_params.length     = reg_size;
+  
+  mh = (ucx_rma_mhandle_t*)malloc(sizeof(ucx_rma_mhandle_t));
+  if (mh == NULL) {
+    return ncclSystemError;
+  }
+
+  UCXCHECK(ucp_mem_map(ctx->ctx, &mmap_params, &mh->ucp_memh));
+  UCXCHECK(ucp_rkey_pack(ctx->ctx, mh->ucp_memh, &mh->rkey_buf,
+                         &mh->rkey_buf_size));
+
+  if (ctx->gpuFlush.enabled) {
+    UCXCHECK(ucp_ep_rkey_unpack(ctx->gpuFlush.flush_ep, mh->rkey_buf, &mh->rkey));
+  }
+  
+  mh->index = ctx->num_mh;
+  ctx->mh[ctx->num_mh] = mh;
+  ctx->num_mh++;
+  *mhandle = mh;
+
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_deregmr(void* comm, void* mhandle)
+{
+  nccl_ucx_rma_ctx_t *ctx = (nccl_ucx_rma_ctx_t*)comm;
+  ucx_rma_mhandle_t  *mh  = (ucx_rma_mhandle_t*)mhandle;
+
+  if (ctx->gpuFlush.enabled) {
+      ucp_rkey_destroy(mh->rkey);
+  }
+  ucp_mem_unmap(ctx->ctx, mh->ucp_memh);
+  free(mh);
+
+  return ncclSuccess;
+}
+
+ncclResult_t ucx_rma_get_request(nccl_ucx_rma_request_t* reqs, int* req_id)
+{
+  nccl_ucx_rma_request_t *r;
+  int i;
+
+  for (i = 0; i < MAX_REQUESTS; i++) {
+    r = reqs + i;
+    if (r->used == 0) {
+      r->used = 1;
+      r->type = 0;
+      r->done = 0;
+      r->size = -1;
+      r->free = 0;
+      r->st   = NULL;
+      *req_id = i;
+      return ncclSuccess;
+    }
+  }
+  WARN("NET/UCX_RMA: unable to allocate requests");
+  *req_id = -1;
+
+  return ncclInternalError;
+}
+
+static void nccl_ucx_rma_flush_cb(void *request, ucs_status_t status)
+{
+  return;
+}
+
+enum {
+  NCCL_UCX_RMA_SCOMM_NOT_READY = 0,
+  NCCL_UCX_RMA_SCOMM_EP_CREATED,
+  NCCL_UCX_RMA_SCOMM_EP_FLUSHED,
+  NCCL_UCX_RMA_SCOMM_WAIT_RKEY,
+  NCCL_UCX_RMA_SCOMM_READY 
+};
+
+static ncclResult_t nccl_ucx_rma_send_check(nccl_ucx_rma_send_comm_t *comm)
+{
+  ucs_status_t st;
+
+  ucp_worker_progress(comm->super.worker);
+  if (comm->super.ready == NCCL_UCX_RMA_SCOMM_NOT_READY) {
+    NCCLCHECK(nccl_ucx_rma_init_ep(comm->super.fd, comm->super.worker, &comm->ep, 0));
+    if (comm->ep == NULL) {
+      return ncclSuccess;
+    }
+    NCCLCHECK(socketReceive(comm->super.fd, &comm->rem_am_id, sizeof(int)));
+    comm->super.ready = NCCL_UCX_RMA_SCOMM_EP_CREATED;
+    NCCLCHECK(socketSend(comm->super.fd, &comm->super.ready, sizeof(int)));
+  }
+
+  if (comm->super.ready == NCCL_UCX_RMA_SCOMM_EP_CREATED) {
+    comm->super.check_req = ucp_ep_flush_nb(comm->ep, 0, nccl_ucx_rma_flush_cb);
+
+    if (comm->super.check_req == NULL) {
+      comm->super.ready = NCCL_UCX_RMA_SCOMM_WAIT_RKEY; 
+    } else if (UCS_PTR_IS_ERR(comm->super.check_req)) {
+      return ncclSystemError;
+    } else {
+      comm->super.ready = NCCL_UCX_RMA_SCOMM_EP_FLUSHED;
+    }
+  }
+
+  if (comm->super.ready == NCCL_UCX_RMA_SCOMM_EP_FLUSHED) {
+    st = ucp_request_check_status(comm->super.check_req);
+    if (st != UCS_INPROGRESS) {
+      ucp_request_free(comm->super.check_req);
+      comm->super.ready = NCCL_UCX_RMA_SCOMM_WAIT_RKEY; 
+    }
+  }
+
+  if ((comm->super.ready == NCCL_UCX_RMA_SCOMM_WAIT_RKEY) &&
+      (comm->rem_key[0] != NULL)) {
+      comm->super.ready = NCCL_UCX_RMA_SCOMM_READY;
+      NCCLCHECK(socketSend(comm->super.fd, &comm->super.ready, sizeof(int)));
+  }
+
+  return ncclSuccess;
+}
+
+enum {
+  NCCL_UCX_RMA_RCOMM_SEND_CONN_INFO = 0,
+  NCCL_UCX_RMA_RCOMM_WAIT_SENDER,
+  NCCL_UCX_RMA_RCOMM_AM_SEND,
+  NCCL_UCX_RMA_RCOMM_WAIT_AM,
+  NCCL_UCX_RMA_RCOMM_WAIT_SCOMM,
+  NCCL_UCX_RMA_RCOMM_READY,
+};
+
+static void nccl_ucx_rma_recv_check_cb(void *request, ucs_status_t status)
+{
+  return;
+}
+
+
+static ncclResult_t nccl_ucx_rma_recv_check(nccl_ucx_rma_recv_comm_t *comm)
+{
+  int bytes = 0;
+  int i, size;
+  int rem_comm_state;
+  char *rkey_bufs_start; 
+  ucs_status_t st;
+
+  ucp_worker_progress(comm->super.worker);
+
+  if (comm->super.ready == NCCL_UCX_RMA_RCOMM_SEND_CONN_INFO) {
+    NCCLCHECK(nccl_ucx_rma_send_worker_address(comm->super.worker, comm->super.fd));
+    NCCLCHECK(socketSend(comm->super.fd, &comm->super.id, sizeof(int)));
+    comm->super.ready = NCCL_UCX_RMA_RCOMM_WAIT_SENDER;
+  }
+
+  if (comm->super.ready == NCCL_UCX_RMA_RCOMM_WAIT_SENDER) {    
+    NCCLCHECK(socketProgress(NCCL_SOCKET_RECV, comm->super.fd, &rem_comm_state,
+                            sizeof(int), &bytes));
+    if (bytes == 0) {
+      return ncclSuccess;
+    }
+
+    NCCLCHECK(socketWait(NCCL_SOCKET_RECV, comm->super.fd, &rem_comm_state,
+                        sizeof(int), &bytes));
+    bytes = 0;
+    if (rem_comm_state == NCCL_UCX_RMA_SCOMM_EP_CREATED) {
+      comm->super.ready = NCCL_UCX_RMA_RCOMM_AM_SEND;
+    } else {
+      WARN("Unexpected socket msg %d (%d)", rem_comm_state, NCCL_UCX_RMA_SCOMM_EP_CREATED);
+      return ncclSystemError;
+    }
+  }
+
+  if (comm->super.ready == NCCL_UCX_RMA_RCOMM_AM_SEND) {
+    size = 2 * sizeof(size_t) + comm->super.num_mh * comm->super.mh[0]->rkey_buf_size;
+    comm->rkey_bufs = malloc(size);
+    memcpy(comm->rkey_bufs, &comm->super.num_mh, sizeof(size_t));
+    memcpy(comm->rkey_bufs + sizeof(size_t), &comm->super.mh[0]->rkey_buf_size, sizeof(size_t));
+    rkey_bufs_start = comm->rkey_bufs + 2 * sizeof(size_t);
+    for (i = 0; i < comm->super.num_mh; i++) {
+      memcpy(rkey_bufs_start, comm->super.mh[i]->rkey_buf, comm->super.mh[i]->rkey_buf_size);
+      rkey_bufs_start += comm->super.mh[i]->rkey_buf_size;
+    }
+    comm->super.check_req = ucp_am_send_nb(comm->ep, comm->rem_am_id, comm->rkey_bufs,
+                                           size, ucp_dt_make_contig(1),
+                                           nccl_ucx_rma_recv_check_cb, 0);
+    ucp_worker_fence(comm->super.worker);
+    if (comm->super.check_req == NULL) {
+      comm->super.ready = NCCL_UCX_RMA_RCOMM_WAIT_SCOMM;
+    } else if (UCS_PTR_IS_ERR(comm->super.check_req)) {
+      return ncclSystemError;
+    } else {
+      comm->super.ready = NCCL_UCX_RMA_RCOMM_WAIT_AM;
+    }
+  }
+
+  if (comm->super.ready == NCCL_UCX_RMA_RCOMM_WAIT_AM) {
+    st = ucp_request_check_status(comm->super.check_req);
+    if (st != UCS_INPROGRESS) {
+      ucp_request_free(comm->super.check_req);
+      free(comm->rkey_bufs);
+      comm->super.ready = NCCL_UCX_RMA_RCOMM_WAIT_SCOMM;
+    }
+  }
+
+  if (comm->super.ready == NCCL_UCX_RMA_RCOMM_WAIT_SCOMM) {
+    NCCLCHECK(socketProgress(NCCL_SOCKET_RECV, comm->super.fd, &rem_comm_state,
+                            sizeof(int), &bytes));
+    if (bytes == 0) {
+      return ncclSuccess;
+    }
+
+    NCCLCHECK(socketWait(NCCL_SOCKET_RECV, comm->super.fd, &rem_comm_state,
+                        sizeof(int), &bytes));
+    if (rem_comm_state == NCCL_UCX_RMA_SCOMM_READY) {
+      comm->super.ready = NCCL_UCX_RMA_RCOMM_READY;
+    } else {
+      WARN("Unexpected socket msg %d (%d)", rem_comm_state, NCCL_UCX_RMA_SCOMM_READY);
+      return ncclSystemError;
+    }    
+  }
+
+  return ncclSuccess;
+}
+
+static void nccl_ucx_rma_dummy_cb(void *request, ucs_status_t status)
+{
+  nccl_ucx_am_request_t *req = (nccl_ucx_am_request_t*)request;
+
+  req->req->done += 1;
+  return;
+}
+
+static void nccl_ucx_rma_send_cb(void *request, ucs_status_t status, void *data)
+{
+  nccl_ucx_rma_request_t *req = (nccl_ucx_rma_request_t*)data;
+
+  req->done += 1;
+  return;
+}
+
+ncclResult_t nccl_ucx_rma_isend(void *send_comm, void *data, int size,
+                                void *mhandle, void **request)
+{
+  nccl_ucx_rma_send_comm_t     *comm = (nccl_ucx_rma_send_comm_t*)send_comm;
+  volatile ucx_rma_send_fifo_t *slot;
+  volatile uint32_t            *ready_ptr;
+  nccl_ucx_rma_request_t       *req;
+  ucs_status_ptr_t             st;
+  int                          req_id;
+  ucp_request_param_t          req_param;
+
+  if (comm->super.ready != NCCL_UCX_RMA_SCOMM_READY) {
+    NCCLCHECK(nccl_ucx_rma_send_check(comm));
+  }
+  if (comm->super.ready != NCCL_UCX_RMA_SCOMM_READY) {
+    *request = NULL;
+    return ncclSuccess;
+  }
+
+  slot = comm->fifo + (comm->fifo_head % MAX_REQUESTS);
+  ready_ptr = &slot->ready;
+  if (*ready_ptr == 0) {
+    ucp_worker_progress(comm->super.worker);
+    *request = NULL;
+    return ncclSuccess;
+  }
+
+  NCCLCHECK(ucx_rma_get_request(comm->super.reqs, &req_id));
+  req = &(comm->super.reqs[req_id]);
+  req->size = size;
+
+  req_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                           UCP_OP_ATTR_FIELD_REQUEST  |
+                           UCP_OP_ATTR_FIELD_USER_DATA;
+  req_param.cb.send      = nccl_ucx_rma_send_cb;
+  req_param.user_data    = req;
+  req_param.request      = &req->used;
+  
+  st  = ucp_put_nbx(comm->ep, data, size, slot->addr,
+                    comm->rem_key[slot->rkey_idx], &req_param);
+
+  req->done = 0;
+  if (UCS_PTR_IS_ERR(st)) {
+    WARN("NET/UCX_RMA: isend pub_nb failed");
+    return ncclInternalError;
+  } else if (st  == NULL) {
+    req->done += 1;
+  }
+
+  ucp_worker_fence(comm->super.worker);
+  req->am_msg = (((uint64_t)slot->req_id) << 32) | ((uint64_t)size);
+  req->st = ucp_am_send_nb(comm->ep, comm->rem_am_id, &req->am_msg, 8,
+                           ucp_dt_make_contig(1), nccl_ucx_rma_dummy_cb, 0);
+
+  if (req->st == NULL) {
+    req->done += 1;
+  } else if (UCS_PTR_IS_PTR(req->st)) {
+    nccl_ucx_am_request_t *am_req = (nccl_ucx_am_request_t*)req->st;
+    am_req->req = req;
+  } else {
+    WARN("NET/UCX_RMA: isend pub_nb failed");
+  }
+
+  req->seq = slot->seq;
+  slot->ready = 0;
+  slot->addr  = 0ULL;
+  slot->size  = 0;
+  slot->seq   = 0;
+  comm->fifo_head++;
+
+  req->worker = comm->super.worker;
+  req->type   = UCX_RMA_REQ_TYPE_SEND;
+  *request = req;
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_post_fifo(nccl_ucx_rma_recv_comm_t *comm,
+                                    ucx_rma_mhandle_t *mh,
+                                    uint64_t addr, int size, int req_id)
+{
+  ucx_rma_send_fifo_t *local_elem;
+  uint64_t            remote_addr;
+  ucs_status_t        st;
+
+  local_elem = comm->rem_fifo.elems + (comm->rem_fifo.tail % MAX_REQUESTS);
+  local_elem->addr     = addr;
+  local_elem->ready    = 1;
+  local_elem->size     = size;
+  local_elem->seq      = comm->rem_fifo.tail;
+  local_elem->rkey_idx = mh->index;
+  local_elem->req_id   = req_id;
+
+  remote_addr = comm->rem_fifo.addr + (comm->rem_fifo.tail % MAX_REQUESTS) *
+                                      sizeof(ucx_rma_send_fifo_t);
+  st = ucp_put_nbi(comm->ep, (void*)local_elem, sizeof(ucx_rma_send_fifo_t),
+                   remote_addr, comm->rem_fifo.rkey);
+  if (st < 0) {
+    WARN("ucx_rma post_fifo pub_nbi failed %d", (int)st);
+    return ncclInternalError;
+  }
+
+  comm->rem_fifo.tail++;
+
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_irecv(void *recv_comm, void *data, int size,
+                                void *mhandle, void **request)
+{
+  nccl_ucx_rma_recv_comm_t *comm = (nccl_ucx_rma_recv_comm_t*)recv_comm;
+  ucx_rma_mhandle_t        *mh   = (ucx_rma_mhandle_t*)mhandle;
+  nccl_ucx_rma_request_t   *req;
+  int                      req_id;
+
+  if (comm->super.ready != NCCL_UCX_RMA_RCOMM_READY) {
+    NCCLCHECK(nccl_ucx_rma_recv_check(comm));
+  }
+
+  if (comm->super.ready != NCCL_UCX_RMA_RCOMM_READY) {
+    *request = NULL;
+    return ncclSuccess;
+  }
+  
+  NCCLCHECK(ucx_rma_get_request(comm->super.reqs, &req_id));
+  req = &comm->super.reqs[req_id];
+
+  req->seq = comm->rem_fifo.tail;
+  NCCLCHECK(nccl_ucx_rma_post_fifo(comm, mh, (uint64_t)data, size,  req_id));
+  ucp_worker_progress(comm->super.worker);
+  req->worker = comm->super.worker;
+  req->type   = UCX_RMA_REQ_TYPE_RECV;
+  *request = req;
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_flush(void* recv_comm, void* data, int size,
+                                void* mhandle)
+{
+  nccl_ucx_rma_recv_comm_t *comm = (nccl_ucx_rma_recv_comm_t*)recv_comm;
+  ucx_rma_mhandle_t        *mh   = (ucx_rma_mhandle_t*)mhandle;
+  nccl_ucx_rma_request_t   *req;
+
+  if ((comm->super.gpuFlush.enabled == 0) || (size == 0)) {
+    return ncclSuccess;
+  }
+
+  req = ucp_get_nb(comm->super.gpuFlush.flush_ep, &comm->super.gpuFlush.hostMem, 1,
+                   (uint64_t)data, mh->rkey, nccl_ucx_rma_flush_cb);
+  if (UCS_PTR_IS_ERR(req)) {
+    WARN("ucx_flush: unable to read data (%s)", ucs_status_string(UCS_PTR_STATUS(req)));
+    return ncclSystemError;
+  } else if (req != NULL) {
+    while(ucp_request_check_status(req) == UCS_INPROGRESS) {
+       ucp_worker_progress(comm->super.worker);
+    }
+    ucp_request_free(req);
+  }
+
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_test(void *request, int *done, int *size)
+{
+  nccl_ucx_rma_request_t *req = (nccl_ucx_rma_request_t*)request;
+  unsigned p;
+
+  *done = 0;
+  do {
+    if (req->done == 2) {
+      *done = 1;
+      if (size) {
+        *size = req->size;
+      }
+      if (req->st != NULL) {
+        ucp_request_free(req->st);
+      }
+      req->used = 0;
+      return ncclSuccess;
+    }
+
+    p = ucp_worker_progress(req->worker);
+  } while (p);
+
+  return ncclSuccess;
+}
+
+static void wait_close(ucp_worker_h worker, nccl_ucx_rma_request_t *req)
+{
+  ucs_status_t status;
+
+  if (UCS_PTR_IS_PTR(req)) {
+    do {
+      ucp_worker_progress(worker);
+      status = ucp_request_check_status(req);
+    } while(status == UCS_INPROGRESS);
+    ucp_request_free(req);
+  } else if (req != NULL) {
+      WARN("Failed to close UCX endpoint");
+  }
+}
+
+ncclResult_t nccl_ucx_rma_close_send(void *send_comm)
+{
+  nccl_ucx_rma_send_comm_t *comm = (nccl_ucx_rma_send_comm_t*) send_comm;
+  void *close_req;
+  int close = 1;
+  int  i;
+
+  if (send_comm) {
+    ucp_mem_unmap(comm->super.ctx, comm->fifo_memh);
+
+    for (i = 0; i < comm->super.num_mh; i++) {
+      if (comm->rem_key[i]) {
+        ucp_rkey_destroy(comm->rem_key[i]);
+      }
+    }
+    if (comm->ep) {
+      close_req = ucp_ep_close_nb(comm->ep, UCP_EP_CLOSE_MODE_FLUSH);
+      wait_close(comm->super.worker, close_req);
+    }
+    NCCLCHECK(socketSend(comm->super.fd, &close, sizeof(int)));
+    nccl_ucx_free_worker(comm->super.worker);
+    free(comm);
+  }
+
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_close_recv(void *recv_comm)
+{
+  nccl_ucx_rma_recv_comm_t *comm = (nccl_ucx_rma_recv_comm_t*)recv_comm;
+  void *close_req;
+  int debug = 1;
+  int close=1;
+
+  if (recv_comm) {
+    ucp_rkey_destroy(comm->rem_fifo.rkey);
+    if (comm->super.gpuFlush.enabled) {
+      close_req = ucp_ep_close_nb(comm->super.gpuFlush.flush_ep, UCP_EP_CLOSE_MODE_FLUSH);
+      wait_close(comm->super.worker, close_req);
+    }
+    if (comm->ep) {
+      close_req = ucp_ep_close_nb(comm->ep, UCP_EP_CLOSE_MODE_FLUSH);
+      wait_close(comm->super.worker, close_req);
+    }
+    NCCLCHECK(socketSend(comm->super.fd, &close, sizeof(int)));  
+    nccl_ucx_free_worker(comm->super.worker);
+    free(comm);
+  }
+  
+  return ncclSuccess;
+}
+
+ncclResult_t nccl_ucx_rma_close_listen(void *listen_comm)
+{
+  nccl_ucx_rma_listen_comm_t *comm = (nccl_ucx_rma_listen_comm_t *)listen_comm;
+
+  if (comm) {
+    close(comm->fd);
+    free(comm);
+  }
+  
+  return ncclSuccess;
+}
+
+ncclNet_t ucxRmaPlugin = {
+  "UCX_RMA",
+  nccl_ucx_rma_init,
+  nccl_ucx_rma_devices,
+  nccl_ucx_rma_get_properties,
+  nccl_ucx_rma_listen,
+  nccl_ucx_rma_connect,
+  nccl_ucx_rma_accept,
+  nccl_ucx_rma_regmr,
+  nccl_ucx_rma_deregmr,
+  nccl_ucx_rma_isend,
+  nccl_ucx_rma_irecv,
+  nccl_ucx_rma_flush,
+  nccl_ucx_rma_test,
+  nccl_ucx_rma_close_send,
+  nccl_ucx_rma_close_recv,
+  nccl_ucx_rma_close_listen
+};
+


### PR DESCRIPTION
Another version of ucx plugin which follows original nccl ib rma implementation but also adds support for additional transports present in ucx e.g. rc_x, dc_x