### PR TITLE
m4/ucx.m4: Fix incorrect variable declaration checks

### DIFF
--- a/m4/ucx.m4
+++ b/m4/ucx.m4
@@ -57,13 +57,13 @@ AS_IF([test "x$ucx_checked" != "xyes"],[
 
         AS_IF([test "x$ucx_happy" = "xyes"],
         [
-            AS_IF([test ! -v "$check_ucx_dir"],
+            AS_IF([test -v "check_ucx_dir"],
             [
                 AC_MSG_RESULT([UCX dir: $check_ucx_dir])
                 AC_SUBST(UCX_CPPFLAGS, "-I$check_ucx_dir/include/")
             ])
 
-            AS_IF([test ! -v "$check_ucx_libdir"],
+            AS_IF([test -v "check_ucx_libdir"],
             [
                 AC_SUBST(UCX_LDFLAGS, "-L$check_ucx_libdir")
             ])


### PR DESCRIPTION
In ucx/m4, the script checks if "check_ucx_dir" and/or
"check_ucx_libdir" variables are declared, and set UCX_LDFLAGS and
UCX_CPPFLAGS accordingly.

Due to misuse of "test" command, condition might be true even when
the variables are not declared.


Signed-off-by: Daniel Klein <danielk@mellanox.com>