### PR TITLE
Align Copyright headers with Nvidia standard

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
-Copyright (C) 2014-2020      Mellanox Technologies Ltd. All rights reserved.
-Copyright (c) 2018-2020      NVIDIA CORPORATION. All rights reserved.
+Copyright (c) 2014-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 
 modification, are permitted provided that the following conditions 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+# Copyright (c) 2019, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See file LICENSE for terms.
 #

--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2019.  ALL RIGHTS RESERVED.
+# Copyright (c) 2019, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # See file LICENSE for terms.
 #
 AC_PREREQ([2.63])
 
-AC_COPYRIGHT([Copyright (C) 2019 Mellanox Technologies Ltd. All rights reserved.])
+AC_COPYRIGHT([Copyright (c) 2019, NVIDIA CORPORATION & AFFILIATES. All rights reserved.])
 
 define([nccl_rdma_sharp_plugins_ver_major], 1)
 define([nccl_rdma_sharp_plugins_ver_minor], 0)

--- a/contrib/buildrpm.sh
+++ b/contrib/buildrpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eE
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2016.  ALL RIGHTS RESERVED.
+# Copyright (c) 2001-2016, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # See file LICENSE for terms.
 #
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,8 +3,7 @@ Upstream-Name: NCCL-RDMA-SHARP plugins
 Source: http://www.mellanox.com
 
 Files: *
-Copyright (C) 2019      Mellanox Technologies Ltd. All rights reserved.
-Copyright (c) 2015-2019, NVIDIA CORPORATION. All rights reserved
+Copyright (c) 2015-2019, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 License: BSD
  Redistribution and use in source and binary forms, with or without 
  modification, are permitted provided that the following conditions 

--- a/include/core.h
+++ b/include/core.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2015-2018, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2015-2018, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/include/ibvwrap.h
+++ b/include/ibvwrap.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2005, 2006, 2007 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2005 PathScale, Inc.  All rights reserved.
  *
- * Copyright (c) 2015-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2015-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/include/nccl.h
+++ b/include/nccl.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2015-2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2015-2019, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/include/nccl_net.h
+++ b/include/nccl_net.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2017-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/include/p2p_plugin.h
+++ b/include/p2p_plugin.h
@@ -1,6 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
- * Copyright (C) 2019-2020, Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2016-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/include/param.h
+++ b/include/param.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2017-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/include/socket.h
+++ b/include/socket.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2016-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/include/timer.h
+++ b/include/timer.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2018, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/m4/sharp.m4
+++ b/m4/sharp.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (c) 2001-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # See file LICENSE for terms.
 #
 

--- a/m4/ucx.m4
+++ b/m4/ucx.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2020.  ALL RIGHTS RESERVED.
+# Copyright (c) 2001-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # See file LICENSE for terms.
 #
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2019-2020.  ALL RIGHTS RESERVED.
+# Copyright (c) 2019-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # See file LICENSE for terms.
 #
 

--- a/src/ib_plugin.c
+++ b/src/ib_plugin.c
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2020, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2016-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/src/ibvwrap.c
+++ b/src/ibvwrap.c
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2015-2018, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/src/p2p_plugin.c
+++ b/src/p2p_plugin.c
@@ -1,6 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2018, NVIDIA CORPORATION. All rights reserved.
- * Copyright (C) 2019-2020, Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2016-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/src/param.c
+++ b/src/param.c
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2019-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/src/sharp_plugin.c
+++ b/src/sharp_plugin.c
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2020, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2016-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2016-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/src/ucx_plugin.c
+++ b/src/ucx_plugin.c
@@ -1,6 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2018, NVIDIA CORPORATION. All rights reserved.
- * Copyright (C) 2019-2020, Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2016-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/src/ucx_rma_plugin.c
+++ b/src/ucx_rma_plugin.c
@@ -1,5 +1,5 @@
 /*************************************************************************
- *  * Copyright (c) 2016-2020, NVIDIA CORPORATION. All rights reserved.
+ *  * Copyright (c) 2016-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *   *
  *    * See LICENSE.txt for license information
  *     ************************************************************************/

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2018, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/


### PR DESCRIPTION
**What**
Align Copyright headers with Nvidia license format.

**Why ?**
Required by NVIDIA legal dept.
[Legal doc](https://confluence.nvidia.com/pages/viewpage.action?pageId=788418816)
[RM-3120447](https://redmine.mellanox.com/issues/3120447)

**How ?**
Auto-generated by the [scanner script](https://github.com/Mellanox-lab/hpcx-build/blob/copyright_scanner/ci/copyright_scanner.py).
/CC @bureddy  @artemry-nv @yosefe