### PR TITLE
Also check whether DMABUF is enabled when setting gpuFlush

### DIFF
--- a/include/p2p_plugin.h
+++ b/include/p2p_plugin.h
@@ -108,6 +108,8 @@ extern struct ncclIbDev userIbDevs[MAX_IB_DEVS];
  * ncclSystemError : no module or module loaded but not supported by GPU */
 ncclResult_t nccl_p2p_gdr_support(int dev);
 
+ncclResult_t nccl_p2p_dmabuf_support(int dev);
+
 ncclResult_t nccl_p2p_ib_pci_path(nccl_ib_dev_t *devs, int num_devs, char* dev_name, char** path, int* real_port);
 
 ncclResult_t nccl_p2p_ib_get_properties(nccl_ib_dev_t *devs, int dev, ncclNetProperties_t* props);

--- a/src/ib_plugin.c
+++ b/src/ib_plugin.c
@@ -488,7 +488,8 @@ ib_recv:
   if (ncclParamIbUseInline()) rComm->remFifo.flags = IBV_SEND_INLINE;
 
   // Allocate Flush dummy buffer for GPU Direct RDMA
-  rComm->gpuFlush.enabled = (nccl_p2p_gdr_support(lComm->dev) == 0) && (ncclParamIbGdrFlushDisable() == 0) ? 1 : 0;
+  rComm->gpuFlush.enabled = ((nccl_p2p_gdr_support(lComm->dev) == ncclSuccess) || nccl_p2p_dmabuf_support(lComm->dev) == ncclSuccess) &&
+                                                 (ncclParamIbGdrFlushDisable() == 0) ? 1 : 0;
   if (rComm->gpuFlush.enabled) {
     NCCLCHECK(wrap_ibv_reg_mr(&rComm->gpuFlush.hostMr, rComm->verbs.pd, &rComm->gpuFlush.hostMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE));
     rComm->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlush.hostMem;

--- a/src/p2p_plugin.c
+++ b/src/p2p_plugin.c
@@ -152,16 +152,13 @@ ncclResult_t nccl_p2p_ib_get_properties(nccl_ib_dev_t *devs, int dev, ncclNetPro
   props->pciPath      = devs[dev].pciPath;
   props->guid         = devs[dev].guid;
   props->ptrSupport   = NCCL_PTR_HOST;
-  if (nccl_p2p_gdr_support(dev) != ncclSuccess) {
-    INFO(NCCL_NET,"NET/IB : GPU Direct RDMA Disabled for HCA %d '%s' (no module)", dev, devs[dev].devName);
-  } else {
-    props->ptrSupport |= NCCL_PTR_CUDA;
-  }
   if (nccl_p2p_gdr_support(dev) == ncclSuccess) {
     props->ptrSupport |= NCCL_PTR_CUDA; // GDR support via nv_peermem
+    INFO(NCCL_NET,"NET/IB : GPU Direct RDMA (nvidia-peermem) enabled for HCA %d '%s", dev, devs[dev].devName);
   }
   if (p2p_plugin == NCCL_P2P_IB && nccl_p2p_dmabuf_support(dev) == ncclSuccess) {
     props->ptrSupport |= NCCL_PTR_DMABUF; // GDR support via DMA-BUF
+    INFO(NCCL_NET,"NET/IB : GPU Direct RDMA (DMABUF) enabled for HCA %d '%s", dev, devs[dev].devName);
   }
 
   props->speed        = devs[dev].speed;


### PR DESCRIPTION
If nvidia-peermem is unloaded and DMABUF is in use we still need to enable the GDRDMA flush mechanism

BUG 4141798