### PR TITLE
Prevent WR index truncation in the InfiniBand transport code

### DIFF
--- a/src/ib_plugin.c
+++ b/src/ib_plugin.c
@@ -783,7 +783,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, int size, int tag, void* mh
   int slot = (comm->fifoHead)%MAX_REQUESTS;
   struct ncclIbRequest** reqs = comm->fifoReqs[slot];
   slots = comm->fifo[slot];
-  int idx = comm->fifoHead+1;
+  uint64_t idx = comm->fifoHead+1;
   if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
   nreqs = slots[0].nreqs;
   // Wait until all data has arrived


### PR DESCRIPTION
See explanation in https://github.com/NVIDIA/nccl/pull/898 committed by my colleague.