### PR TITLE
UCX plugin: Add multi-receive posting to avoid excessive flush

### DIFF
--- a/src/p2p_plugin.c
+++ b/src/p2p_plugin.c
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/

--- a/src/p2p_plugin.c
+++ b/src/p2p_plugin.c
@@ -187,9 +187,9 @@ ncclResult_t nccl_p2p_ib_get_properties(nccl_ib_dev_t *devs, int dev, ncclNetPro
   props->port         = devs[dev].port + devs[dev].realPort;
   props->maxComms     = devs[dev].maxQp;
   if (p2p_plugin == NCCL_P2P_IB || p2p_plugin == NCCL_P2P_UCX) {
-      props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
+    props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
   } else {
-      props->maxRecvs = 1;
+    props->maxRecvs = 1;
   }
   props->netDeviceType    = NCCL_NET_DEVICE_HOST;
   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;

--- a/src/p2p_plugin.c
+++ b/src/p2p_plugin.c
@@ -186,7 +186,11 @@ ncclResult_t nccl_p2p_ib_get_properties(nccl_ib_dev_t *devs, int dev, ncclNetPro
   props->latency      = 0; // Not set
   props->port         = devs[dev].port + devs[dev].realPort;
   props->maxComms     = devs[dev].maxQp;
-  props->maxRecvs     = (p2p_plugin == NCCL_P2P_IB) ? NCCL_NET_IB_MAX_RECVS : 1;
+  if (p2p_plugin == NCCL_P2P_IB || p2p_plugin == NCCL_P2P_UCX) {
+      props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
+  } else {
+      props->maxRecvs = 1;
+  }
   props->netDeviceType    = NCCL_NET_DEVICE_HOST;
   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
 

--- a/src/ucx_plugin.c
+++ b/src/ucx_plugin.c
@@ -624,6 +624,7 @@ static ncclResult_t ucx_send_check(ucx_comm_t *comm) {
       status = ucp_request_check_status(ucp_req);
     } while (status == UCS_INPROGRESS);
     assert(status == UCS_OK);
+    ucp_request_free(ucp_req);
   }
 
   ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;

--- a/src/ucx_plugin.c
+++ b/src/ucx_plugin.c
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2016-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/
@@ -40,23 +40,6 @@ static const ucp_tag_t tag      = 0x8a000000;
 static const ucp_tag_t tag_mask = (uint64_t)(-1);
 
 static int ncclNIbDevs = -1;
-
-/*
- * If request == REQUEST_COMPLETED_ZERO_LENGTGH:
- *  ucp_send or ucp_recv was completed immediately and worker progress is not needed
- *  message size == 0 and gpu flush is not needed
- * 
- * If request == REQUEST_COMPLETED_NON_ZERO_LENGTH:
- *  ucp_send or ucp_recv was completed immediately and worker progres is not needed
- *  message size > 0 and gpu flush is needed
- * 
- * If request != REQUEST_COMPLETED_ZERO_LENGTGH and request != REQUEST_COMPLETED_NON_ZERO_LENGTH:
- *  normal ucp request.
- */
-enum {
-  REQUEST_COMPLETED_ZERO_LENGTGH    = 1,
-  REQUEST_COMPLETED_NON_ZERO_LENGTH = 2
-};
 
 enum ncclUCXCommState {
   ncclUCXCommStateStart = 0,

--- a/src/ucx_plugin.c
+++ b/src/ucx_plugin.c
@@ -610,11 +610,9 @@ static ncclResult_t ucx_send_check(ucx_comm_t *comm) {
 
   params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK  |
                         UCP_OP_ATTR_FIELD_USER_DATA |
-                        UCP_OP_ATTR_FIELD_DATATYPE  |
                         UCP_OP_ATTR_FLAG_NO_IMM_CMPL;
   params.cb.recv      = recv_handler_nbx;
   params.user_data    = &pending;
-  params.datatype     = ucp_dt_make_contig(1);
   ucp_req = ucp_tag_msg_recv_nbx(comm->worker, msg, info_tag.length,
                                  msg_tag, &params);
   if (UCS_PTR_IS_ERR(ucp_req)) {
@@ -670,11 +668,9 @@ ncclResult_t ucx_recv_check(ucx_comm_t *comm) {
   memcpy(comm->msg + 1, my_addr, local_addr_len);
 
   params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
-                        UCP_OP_ATTR_FIELD_USER_DATA |
-                        UCP_OP_ATTR_FIELD_DATATYPE;
+                        UCP_OP_ATTR_FIELD_USER_DATA;
   params.cb.send      = check_handler;
   params.user_data    = comm;
-  params.datatype     = ucp_dt_make_contig(1);
 
   comm->connect_req   = ucp_tag_send_nbx(comm->ep, comm->msg, msg_len,
                                          comm->ctag, &params);
@@ -724,11 +720,9 @@ static ncclResult_t nccl_ucx_isend(void *send_comm, void *data, int size,
   ucx_request_add(req, size);
 
   params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
-                        UCP_OP_ATTR_FIELD_USER_DATA |
-                        UCP_OP_ATTR_FIELD_DATATYPE;
+                        UCP_OP_ATTR_FIELD_USER_DATA;
   params.cb.send      = send_handler_nbx;
   params.user_data    = &req->pending;
-  params.datatype     = ucp_dt_make_contig(1);
   if (mh) {
     params.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMORY_TYPE;
     params.memory_type   = mh->mem_type;
@@ -780,11 +774,9 @@ static ncclResult_t nccl_ucx_irecv(void *recv_comm, int n, void **data,
     ucx_request_add(req, sizes[i]);
 
     params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
-                          UCP_OP_ATTR_FIELD_USER_DATA |
-                          UCP_OP_ATTR_FIELD_DATATYPE;
+                          UCP_OP_ATTR_FIELD_USER_DATA;
     params.cb.recv      = recv_handler_nbx;
     params.user_data    = &req->pending;
-    params.datatype     = ucp_dt_make_contig(1);
     if (mh[i]) {
       params.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMORY_TYPE;
       params.memory_type   = mh[i]->mem_type;

--- a/src/ucx_plugin.c
+++ b/src/ucx_plugin.c
@@ -532,12 +532,9 @@ ncclResult_t nccl_ucx_regmr(void* comm, void* data, int size, int type, void** m
                            UCP_MEM_MAP_PARAM_FIELD_LENGTH; 
   mmap_params.address    = (void*)reg_addr;
   mmap_params.length     = reg_size;  
-  mh->mem_type = type;
-#if UCP_API_VERSION >= UCP_VERSION(1, 10)
   mh->mem_type = (type == NCCL_PTR_HOST)? UCS_MEMORY_TYPE_HOST: UCS_MEMORY_TYPE_CUDA;
   mmap_params.field_mask  |= UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE; 
   mmap_params.memory_type = mh->mem_type;
-#endif
 
   UCXCHECK(ucp_mem_map(ctx->ucp_ctx, &mmap_params, &mh->ucp_memh));
   if (ctx->gpuFlush.enabled) {

--- a/src/ucx_rma_plugin.c
+++ b/src/ucx_rma_plugin.c
@@ -655,12 +655,9 @@ ncclResult_t nccl_ucx_rma_regmr(void* comm, void* data, int size, int type,
                            UCP_MEM_MAP_PARAM_FIELD_LENGTH; 
   mmap_params.address    = (void*)reg_addr;
   mmap_params.length     = reg_size;  
-  mh->mem_type = type;
-#if UCP_API_VERSION >= UCP_VERSION(1, 10)
   mh->mem_type = (type == NCCL_PTR_HOST)? UCS_MEMORY_TYPE_HOST: UCS_MEMORY_TYPE_CUDA;
   mmap_params.field_mask  |= UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE; 
   mmap_params.memory_type = mh->mem_type;
-#endif
 
   UCXCHECK(ucp_mem_map(ctx->ctx, &mmap_params, &mh->ucp_memh));
   UCXCHECK(ucp_rkey_pack(ctx->ctx, mh->ucp_memh, &rkey_buf, &mh->rkey_buf.rkey_buf_size));
@@ -903,12 +900,10 @@ ncclResult_t nccl_ucx_rma_isend(void *send_comm, void *data, int size, int tag,
   req_param.cb.send      = nccl_ucx_rma_put_isend_cb;
   req_param.user_data    = req;
   req_param.request      = &req->used;
-#if UCP_API_VERSION >= UCP_VERSION(1,10)
   if (mh) {
     req_param.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMORY_TYPE;
     req_param.memory_type  =  mh->mem_type;
   }
-#endif
   
   st  = ucp_put_nbx(comm->ep, data, size, slot->addr,
                     comm->rkeys[*rkey_index].rkey,


### PR DESCRIPTION
## What?
Add to UCX plugin the capability to post multiple receives at once.

## Why?
Posting 8 receives at once reduces the flushing by 8 times, which fixes perf on alltoall_perf (nccl-test).

Selene luna, alltoall_perf, 4 nodes, 32 gpus, tested 1 gpu x 8 processes on 4 nodes, tested 8 gpus x 1 process on 4 nodes
- **Internal IB / UCX Before / UCX After: 31.84 / 24.27 / 31.89**

## How?
- Add multi-request handling
- Remove support for UCX <1.10 (was not building since 1+ year)
- Merge comm descriptor

### Tested

nccl-test alltoall, allreduce

Versions:
- UCX 96dcb9fc20353cc59478256e33eba152751fa4b4
- nccl-rdma-sharp-plugins d387b8a8e7c5f3639ed8957fdfdb8cdaf98aca94
- nccl 4365458757e4107ecbf629b2fd6e0e19a5d237c2 (~v2.18.5-1)

Command:
```
NCCL_PLUGIN_P2P=ucx
NCCL_UCX_TLS=rc,cuda_copy,cuda_ipc
all_reduce_perf -b 8 -e 8G -f 2 -g 8 -t 1 -w 100
```