### PR TITLE
Add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+IndentWidth: 2
+AlignEscapedNewlines: Indent
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignConsecutiveStructMembers: true
+AlignConsecutiveMacros: true
+AlignDeclarationByPointer: true
+AlignAfterOpenBracket: true
+AlignOperands: true


### PR DESCRIPTION
Add simplest clang format file, matching existing coding style.
- usage: `git clang-format --diff HEAD^ HEAD`.