### PR TITLE
Enable all compile warnings and fix errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,9 +50,9 @@ AC_ARG_ENABLE([debug],AS_HELP_STRING([--enable-debug], [Enable extra debugging c
 
 if test $enable_debug = yes; then
 	AC_DEFINE([ENABLE_DEBUG], [1], [Enable debugging code])
-	CFLAGS="$CFLAGS -O0 -g3 -Werror"
+	CFLAGS="$CFLAGS -O0 -g3 -Wall -Werror"
 else
-	CFLAGS="$CFLAGS -O3 -DNDEBUG -Werror"
+	CFLAGS="$CFLAGS -O3 -DNDEBUG -Wall -Werror"
 fi
 
 #check for cuda

--- a/include/p2p_plugin.h
+++ b/include/p2p_plugin.h
@@ -9,8 +9,6 @@
 
 #include <stdint.h>
 #include <unistd.h>
-#define ENABLE_TIMER 0
-#include "timer.h"
 #include <assert.h>
 
 #include "nccl.h"

--- a/include/timer.h
+++ b/include/timer.h
@@ -52,9 +52,9 @@ static double startTimes[8];
   printf("\n"); \
 } while (0);
 #else
-#define TIME_START(index) while(0);
-#define TIME_STOP(index) while(0);
-#define TIME_CANCEL(index) while(0);
+#define TIME_START(index) do {} while(0);
+#define TIME_STOP(index) do {} while(0);
+#define TIME_CANCEL(index) do {} while(0);
 #define TIME_PRINT(name)
 #endif
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -26,7 +26,6 @@ struct netIf {
 
 int parseStringList(const char* string, struct netIf* ifList, int maxList);
 int matchIfList(const char* string, int port, struct netIf* ifList, int listSize, int matchExact);
-int readFileNumber(long *value, const char *filename_fmt, ...);
 const char *get_plugin_lib_path();
 
 #endif

--- a/src/p2p_plugin.c
+++ b/src/p2p_plugin.c
@@ -65,7 +65,6 @@ static nccl_p2p_plugin_t p2p_plugin = NCCL_P2P_LAST;
 
 static void pluginSetup()
 {
-
   p2p_plugin = NCCL_P2P_IB;
   const char *plugin_path = get_plugin_lib_path();
   if (plugin_path != NULL) {
@@ -84,11 +83,6 @@ static void pluginSetup()
     }
   }
   switch (p2p_plugin) {
-    case NCCL_P2P_IB:
-      ncclNetPlugin_v7 = ibPlugin_v7;
-      ncclNetPlugin_v6 = ibPlugin_v6;
-      ncclNetPlugin_v5 = ibPlugin_v5;
-      break;
 #ifdef HAVE_UCX_PLUGIN
     case NCCL_P2P_UCX:
       ncclNetPlugin_v7 = ucxPlugin_v7;
@@ -101,6 +95,11 @@ static void pluginSetup()
       ncclNetPlugin_v5 = ucxRmaPlugin_v5;
       break;
 #endif
+    default:
+      ncclNetPlugin_v7 = ibPlugin_v7;
+      ncclNetPlugin_v6 = ibPlugin_v6;
+      ncclNetPlugin_v5 = ibPlugin_v5;
+      break;
   }
 
 }
@@ -413,4 +412,3 @@ nccl_p2p_plugin_t nccl_p2p_get_plugin_type()
 
 struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
 struct ncclIbDev userIbDevs[MAX_IB_DEVS];
-

--- a/src/sharp_plugin.c
+++ b/src/sharp_plugin.c
@@ -138,7 +138,7 @@ int ncclSharpAllGather(void *context, void *buf, int len) {
        if (rrequest == NULL) NCCLCHECK(ncclNetPlugin_v7.irecv(cComm->recvComm, 1, &rbuf, &len, &tag, &rMhandle, &rrequest));
     }
     while (srequest || rrequest) {
-      int done;
+      int done = 0; /* silent uninitialized false positive */
       if (rrequest) NCCLCHECK(ncclNetPlugin_v7.test(rrequest, &done, NULL));
       if (done) rrequest = NULL;
       if (srequest) NCCLCHECK(ncclNetPlugin_v7.test(srequest, &done, NULL));

--- a/src/utils.c
+++ b/src/utils.c
@@ -110,60 +110,6 @@ int matchIfList(const char* string, int port, struct netIf* ifList, int listSize
   return 0;
 }
 
-static size_t readFileVarArg(char *buffer, size_t max,
-    const char *filename_fmt, va_list ap)
-{
-  char filename[PATH_MAX];
-  ssize_t read_bytes;
-  int fd;
-
-  vsnprintf(filename, PATH_MAX, filename_fmt, ap);
-
-  fd = open(filename, O_RDONLY);
-  if (fd < 0) {
-    return -1;
-  }
-
-  read_bytes = read(fd, buffer, max - 1);
-  if (read_bytes < 0) {
-    return -1;
-  }
-
-  if (read_bytes < max) {
-    buffer[read_bytes] = '\0';
-  }
-
-out_close:
-  close(fd);
-}
-
-int readFileNumber(long *value, const char *filename_fmt, ...)
-{
-  char buffer[64], *tail;
-  ssize_t read_bytes;
-  va_list ap;
-  long n;
-
-  va_start(ap, filename_fmt);
-  read_bytes = readFileVarArg(buffer, sizeof(buffer) - 1,
-      filename_fmt, ap);
-  va_end(ap);
-
-  if (read_bytes < 0) {
-    /* read error */
-    return -1;
-  }
-
-  n = strtol(buffer, &tail, 0);
-  if ((*tail != '\0') && !isspace(*tail)) {
-    /* parse error */
-    return -1;
-  }
-
-  *value = n;
-  return 0;
-}
-
 const char *get_plugin_lib_path()
 {
   Dl_info dl_info;


### PR DESCRIPTION
## What
Enable all warnings and fix issues.

## How
Tested: clang-12, gcc-4.8.5, `--with-sharp` and `--with-ucx`, with/without `--enable-debug` and `ENABLE_TIMER` set.