### PR TITLE
Use IB_MERGE_VFS argument when detecting PCI path

### DIFF
--- a/include/p2p_plugin.h
+++ b/include/p2p_plugin.h
@@ -123,6 +123,8 @@ int nccl_p2p_ib_speed(int speed);
 
 int64_t ncclParamSharpMaxComms();
 
+int64_t ncclParamIbMergeVfs();
+
 int ncclIbRelaxedOrderingCapable(void);
 
 nccl_p2p_plugin_t nccl_p2p_get_plugin_type();

--- a/src/p2p_plugin.c
+++ b/src/p2p_plugin.c
@@ -385,7 +385,7 @@ ncclResult_t nccl_p2p_ib_pci_path(nccl_ib_dev_t *devs, int num_devs, char* dev_n
     // Merge multi-port NICs into the same PCI device
     p[strlen(p)-1] = '0';
     // Also merge virtual functions (VF) into the same device
-    p[strlen(p)-3] = '0';
+    if (ncclParamIbMergeVfs()) p[strlen(p)-3] = p[strlen(p)-4] = '0';
     // And keep the real port aside (the ibv port is always 1 on recent cards)
     *real_port = 0;
     for (int d=0; d<num_devs; d++) {


### PR DESCRIPTION
When running in a cloud-hypervisor virtual-machine, IB VFs are exposed as a RCiEP. If the IB VFs are merged, the nccl-rdma-sharp-plugin incorrectly assumes that all IB virtual-functions are part of the PCI host bridge. Disabling the IB_MERGE_VFS variable allows NCCL to correctly identify IB VFs as independent devices.

This is the same logic used by NCCL native IB transport, it should be used here as well.